### PR TITLE
Upgrade to Django3.2 and Document DATABASE_URL

### DIFF
--- a/puzzlebot/settings.py
+++ b/puzzlebot/settings.py
@@ -138,3 +138,6 @@ LOGGING = {
         'level': 'INFO',
     },
 }
+
+# Restore the default primary key field from django 3.1 and earlier
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/puzzlebot/settings.py
+++ b/puzzlebot/settings.py
@@ -68,6 +68,7 @@ WSGI_APPLICATION = 'puzzlebot.wsgi.application'
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
 DATABASES = {
+        # Generates a database configuration from the DATABASE_URL environment variable
         'default': dj_database_url.config(
             default='sqlite:///' + str(BASE_DIR / 'db.sqlite3'),
             conn_max_age=600),

--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -4,14 +4,14 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 class Tier(models.Model):
-	number = models.PositiveSmallIntegerField(unique=True)
+	number = models.PositiveSmallIntegerField(primary_key=True)
 	num_to_unlock = models.PositiveSmallIntegerField()
 	
 	def __str__(self):
 		return 'Tier ' + str(self.number) + ' (' + str(self.num_to_unlock) + ' to unlock)'
 
 class Puzzle(models.Model):
-	number = models.PositiveSmallIntegerField(unique=True)
+	number = models.PositiveSmallIntegerField(primary_key=True)
 	tier = models.ForeignKey(Tier, on_delete=models.CASCADE)
 	answer = models.CharField(max_length=100)
 	

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>3.1, <3.2
+Django>3.2, <3.3
 dj-database-url==0.5.0
 psycopg2-binary>2.9, <3.0
 whitenoise==6.0.0


### PR DESCRIPTION
3.2 is a supported release and requires only one very minimal change

Document DATABASE_URL since that's a non-obvious configuration